### PR TITLE
Prevent php notices on empty field values

### DIFF
--- a/views_json.module
+++ b/views_json.module
@@ -200,6 +200,9 @@ function _views_json_render_fields($view, $row) {
       // For fields with result content, we need to use field-specific logic.
       if ($handler == 'field' && isset($row->$fieldname)) {
         $field_id = "field_{$id}";
+        if (!isset($row->{$field_id}[0])) {
+          continue;
+        }
         switch ($field->field_info['type']) {
           case 'taxonomy_term_reference':
             $field_raw = $row->{$field_id}[0]['raw']['taxonomy_term']->name;

--- a/views_json.module
+++ b/views_json.module
@@ -200,7 +200,7 @@ function _views_json_render_fields($view, $row) {
       // For fields with result content, we need to use field-specific logic.
       if ($handler == 'field' && isset($row->$fieldname)) {
         $field_id = "field_{$id}";
-        if (!isset($row->{$field_id}[0])) {
+        if (empty($row->{$field_id})) {
           continue;
         }
         switch ($field->field_info['type']) {


### PR DESCRIPTION
Not a big deal: do not try to access something within an empty array.